### PR TITLE
Adding DM7 signal to NEXAFS data collection

### DIFF
--- a/rsoxs/Functions/common_procedures.py
+++ b/rsoxs/Functions/common_procedures.py
@@ -12,6 +12,7 @@ from ..HW.signals import (
     Izero_Mesh_int,
     Beamstop_WAXS,
     Beamstop_WAXS_int,
+    DownstreamLargeDiode_int,
     Sample_TEY,
     Sample_TEY_int,
     Beamstop_SAXS,
@@ -119,7 +120,7 @@ def buildeputable(
         
         yield from bps.mv(mono_en, energy,en.scanlock, False,epu_gap,startgap)
         yield from fly_max(
-            [Izero_Mesh_int, Beamstop_WAXS_int],
+            [Izero_Mesh_int, Beamstop_WAXS_int, DownstreamLargeDiode_int],
             [
                 "RSoXS Au Mesh Current",
                 "WAXS Beamstop",
@@ -250,7 +251,7 @@ def Scan_izero_peak(startingen, widfract):
     ps = PeakStats("en_energy", "RSoXS Au Mesh Current")
     yield from subs_wrapper(
         tune_max(
-            [Izero_Mesh, Beamstop_WAXS],
+            [Izero_Mesh, Beamstop_WAXS, DownstreamLargeDiode_int],
             "RSoXS Au Mesh Current",
             mono_en,
             min(2100, max(72, startingen - 10 * widfract)),
@@ -273,6 +274,7 @@ def buildeputablegaps(start, stop, step, widfract, startingen, name, phase, grat
     gapsout = []
     heights = []
     Beamstop_WAXS.kind = "hinted"
+    DownstreamLargeDiode_int.kind = "hinted"
     Izero_Mesh.kind = "hinted"
     epu_gap.kind = "hinted"
     # startinggap = epugap_from_energy(ens[0]) #get starting position from existing table
@@ -292,7 +294,7 @@ def buildeputablegaps(start, stop, step, widfract, startingen, name, phase, grat
         yield from bps.mv(mono_en, max(72, startingen - 10 * widfract))
         peaklist = []
         yield from tune_max(
-            [Izero_Mesh, Beamstop_WAXS],
+            [Izero_Mesh, Beamstop_WAXS, DownstreamLargeDiode_int],
             "RSoXS Au Mesh Current",
             mono_en,
             min(2100, max(72, startingen - 10 * widfract)),
@@ -348,6 +350,7 @@ def do_2020_eputables():
 def do_2023_eputables():
     Izero_Mesh.kind = "hinted"
     Beamstop_WAXS.kind = "hinted"
+    DownstreamLargeDiode_int.kind = "hinted"
     mono_en.readback.kind = "hinted"
     mono_en.kind = "hinted"
     mono_en.read_attrs = ["readback"]

--- a/rsoxs/Functions/energyscancore.py
+++ b/rsoxs/Functions/energyscancore.py
@@ -54,7 +54,7 @@ from ..HW.motors import (
 )
 from sst_hw.mirrors import mir3
 from ..HW.detectors import waxs_det#, saxs_det
-from ..HW.signals import DiodeRange,Beamstop_WAXS,Beamstop_SAXS,Izero_Mesh,Sample_TEY, Beamstop_SAXS_int,Beamstop_WAXS_int, Izero_Mesh_int,Sample_TEY_int, ring_current
+from ..HW.signals import DiodeRange,Beamstop_WAXS,Beamstop_SAXS,Izero_Mesh,Sample_TEY, Beamstop_SAXS_int,Beamstop_WAXS_int, DM7_Photodiode_int, Izero_Mesh_int,Sample_TEY_int, ring_current
 from ..HW.lakeshore import tem_tempstage
 from ..Functions.alignment import rotate_now
 from ..Functions.common_procedures import set_exposure
@@ -131,7 +131,7 @@ def NEXAFS_step_scan_core(
 ):
     # grab locals
     if dets is None:
-        dets = [Beamstop_SAXS_int,Beamstop_WAXS_int, Izero_Mesh_int,Sample_TEY_int]
+        dets = [Beamstop_SAXS_int,Beamstop_WAXS_int, DM7_Photodiode_int, Izero_Mesh_int,Sample_TEY_int]
     if energies is None:
         energies = []
     if times is None:
@@ -366,7 +366,7 @@ def new_en_scan_core(
     master_plan=None,   # if this is lying within an outer plan, that name can be stored here
     sim_mode=False,  # if true, check all inputs but do not actually run anything
     md=None,  # md to pass to the scan
-    signals = [Beamstop_WAXS_int, Beamstop_SAXS_int, Izero_Mesh_int, Sample_TEY_int,mono_en,epu_gap,ring_current],
+    signals = [Beamstop_WAXS_int, Beamstop_SAXS_int, DM7_Photodiode_int, Izero_Mesh_int, Sample_TEY_int,mono_en,epu_gap,ring_current],
     check_exposure = False,
     **kwargs #extraneous settings from higher level plans are ignored
 ):
@@ -1062,7 +1062,7 @@ def flyer_scan_energy(scan_params, sigs=[], md={},locked=True,polarization=0):
         metadata
 
     """
-    detectors = [Beamstop_WAXS_int, Beamstop_SAXS_int, Izero_Mesh_int, Sample_TEY_int]
+    detectors = [Beamstop_WAXS_int, Beamstop_SAXS_int, DM7_Photodiode_int, Izero_Mesh_int, Sample_TEY_int]
 
 
     _md = {

--- a/rsoxs/Functions/energyscancore.py
+++ b/rsoxs/Functions/energyscancore.py
@@ -54,7 +54,7 @@ from ..HW.motors import (
 )
 from sst_hw.mirrors import mir3
 from ..HW.detectors import waxs_det#, saxs_det
-from ..HW.signals import DiodeRange,Beamstop_WAXS,Beamstop_SAXS,Izero_Mesh,Sample_TEY, Beamstop_SAXS_int,Beamstop_WAXS_int, DM7_Photodiode_int, Izero_Mesh_int,Sample_TEY_int, ring_current
+from ..HW.signals import DiodeRange,Beamstop_WAXS,Beamstop_SAXS,Izero_Mesh,Sample_TEY, Beamstop_SAXS_int,Beamstop_WAXS_int, DownstreamLargeDiode_int, Izero_Mesh_int,Sample_TEY_int, ring_current
 from ..HW.lakeshore import tem_tempstage
 from ..Functions.alignment import rotate_now
 from ..Functions.common_procedures import set_exposure
@@ -131,7 +131,7 @@ def NEXAFS_step_scan_core(
 ):
     # grab locals
     if dets is None:
-        dets = [Beamstop_SAXS_int,Beamstop_WAXS_int, DM7_Photodiode_int, Izero_Mesh_int,Sample_TEY_int]
+        dets = [Beamstop_SAXS_int,Beamstop_WAXS_int, DownstreamLargeDiode_int, Izero_Mesh_int,Sample_TEY_int]
     if energies is None:
         energies = []
     if times is None:
@@ -366,7 +366,7 @@ def new_en_scan_core(
     master_plan=None,   # if this is lying within an outer plan, that name can be stored here
     sim_mode=False,  # if true, check all inputs but do not actually run anything
     md=None,  # md to pass to the scan
-    signals = [Beamstop_WAXS_int, Beamstop_SAXS_int, DM7_Photodiode_int, Izero_Mesh_int, Sample_TEY_int,mono_en,epu_gap,ring_current],
+    signals = [Beamstop_WAXS_int, Beamstop_SAXS_int, Izero_Mesh_int, Sample_TEY_int,mono_en,epu_gap,ring_current],
     check_exposure = False,
     **kwargs #extraneous settings from higher level plans are ignored
 ):
@@ -763,7 +763,7 @@ def NEXAFS_old_fly_scan_core(
         yield from grating_to_250(hopgx=hopgx,hopgy=hopgy,hopgtheta=hopgth)
     elif grating == "rsoxs":
         yield from grating_to_rsoxs(hopgx=hopgx,hopgy=hopgy,hopgtheta=hopgth)
-    signals = [Beamstop_WAXS, Beamstop_SAXS, Izero_Mesh, Sample_TEY]
+    signals = [Beamstop_WAXS, Beamstop_SAXS, DownstreamLargeDiode_int, Izero_Mesh, Sample_TEY]
     if np.isnan(pol):
         pol = en.polarization.setpoint.get()
     (en_start, en_stop, en_speed) = scan_params[0]
@@ -890,7 +890,7 @@ def NEXAFS_fly_scan_core(
         yield from grating_to_250(hopgx=hopgx,hopgy=hopgy,hopgtheta=hopgth)
     elif grating == "rsoxs":
         yield from grating_to_rsoxs(hopgx=hopgx,hopgy=hopgy,hopgtheta=hopgth)
-    signals = [Beamstop_WAXS, Izero_Mesh, Sample_TEY]
+    signals = [Beamstop_WAXS, DownstreamLargeDiode_int, Izero_Mesh, Sample_TEY]
     if np.isnan(pol):
         pol = en.polarization.setpoint.get()
     (en_start, en_stop, en_speed) = scan_params[0]
@@ -1062,7 +1062,7 @@ def flyer_scan_energy(scan_params, sigs=[], md={},locked=True,polarization=0):
         metadata
 
     """
-    detectors = [Beamstop_WAXS_int, Beamstop_SAXS_int, DM7_Photodiode_int, Izero_Mesh_int, Sample_TEY_int]
+    detectors = [Beamstop_WAXS_int, Beamstop_SAXS_int, DownstreamLargeDiode_int, Izero_Mesh_int, Sample_TEY_int]
 
 
     _md = {

--- a/rsoxs/Functions/fly_alignment.py
+++ b/rsoxs/Functions/fly_alignment.py
@@ -18,7 +18,7 @@ from sst_hw.diode import Shutter_control, Shutter_enable
 from ..startup import RE, db,  db0, sd, rsoxs_config #bec,
 from ..HW.energy import en
 
-from ..HW.signals import Beamstop_SAXS, Beamstop_WAXS, Beamstop_WAXS_int
+from ..HW.signals import Beamstop_SAXS, Beamstop_WAXS, Beamstop_WAXS_int, DownstreamLargeDiode_int
 from ..HW.motors import (
     sam_X,
     sam_Y,
@@ -346,14 +346,15 @@ def fly_find_fiducials(f2=[3.5,-1,-2.4,1.5],f1=[2.0,-0.9,-1.5,0.8],y1=-187.5,y2=
     yield from bps.mv(Shutter_control, 0)
     yield from load_configuration("WAXSNEXAFS")
     Beamstop_WAXS_int.kind = "hinted"
+    DownstreamLargeDiode_int.kind = "hinted"
     # bec.enable_plots()
     startys = [y2, y1]  # af2 first because it is a safer location
     maxlocs = []
     for startxs, starty in zip(startxss, startys):
         yield from bps.mv(sam_Y, starty, sam_X, startxs[1], sam_Th, 0, sam_Z, 0)
         peaklist = []
-        yield from fly_max([Beamstop_WAXS_int],
-                           ['WAXS Beamstop'],
+        yield from fly_max([Beamstop_WAXS_int, DownstreamLargeDiode_int],
+                           ['WAXS Beamstop', "DownstreamLargeDiode"],
                            sam_Y,
                            starty-1,
                            starty+1,
@@ -366,8 +367,8 @@ def fly_find_fiducials(f2=[3.5,-1,-2.4,1.5],f1=[2.0,-0.9,-1.5,0.8],y1=-187.5,y2=
             yield from bps.mv(sam_X, startx, sam_Th, angle)
             yield from bps.mv(Shutter_control, 1)
             peaklist = []
-            yield from fly_max([Beamstop_WAXS_int],
-                                ['WAXS Beamstop'],
+            yield from fly_max([Beamstop_WAXS_int, DownstreamLargeDiode_int],
+                                ['WAXS Beamstop', "DownstreamLargeDiode"],
                                 sam_X,
                                 startx - 0.5 * xrange,
                                 startx + 0.5 * xrange,

--- a/rsoxs/HW/signals.py
+++ b/rsoxs/HW/signals.py
@@ -269,10 +269,10 @@ Izero_update_time = EpicsSignal(
 
 DiodeRange = EpicsSignal("XF:07ID-ES1{DMR:I400-1}:RANGE_BP")
 
-DM7_Photodiode_int = ophScalar(
+DownstreamLargeDiode_int = ophScalar(
     "XF:07ID-ES1{DMR:I400-1}:IC4_MON", ## PK: Copied over ID from Beamstop_SAXS_int and just changed to "IC4", as the signal is coming from Channel 4.  Also confirmed the name on phoebus RSoXS archiver.
-    name="DM7 Photodiode", 
-    kind="normal" ## PK: following the other examples.  What does "normal" mean?
+    name="DownstreamLargeDiode", ## Large area photodiode in diagnostic module (DM) 7 downstream of RSoXS chamber and M4
+    kind="normal" ## Refers to hinting.  By default, there is omitted, config (recorded once if the device is used in a scan, e.g., slit positions in baseline datastream), normal (recorded for every reading if the device is used in a scan, e.g., beamstop signal at every time/energy point), and hinted (normal but also added to any plots)
 )
 # DM7_Diode = EpicsSignalRO('XF:07ID-BI{DM7:I400-1}:IC4_MON',name = 'DM7 Photodiode', kind='normal')
 DM4_PD = EpicsSignalRO(
@@ -281,7 +281,7 @@ DM4_PD = EpicsSignalRO(
 
 # scalars (integrating detectors)
 
-Beamstop_WAXS_int = ophScalar(
+Beamstop_WAXS_int = ophScalar( ## _int refers to signals that should be flyable, vs. those that do not have _int should not be flyable in theory, though that does not seem to be the case in practice
     "XF:07ID-ES1{DMR:I400-1}:IC1_MON", name="WAXS Beamstop", kind="normal"
 )
 Beamstop_SAXS_int = ophScalar(

--- a/rsoxs/HW/signals.py
+++ b/rsoxs/HW/signals.py
@@ -269,6 +269,11 @@ Izero_update_time = EpicsSignal(
 
 DiodeRange = EpicsSignal("XF:07ID-ES1{DMR:I400-1}:RANGE_BP")
 
+DM7_Photodiode_int = ophScalar(
+    "XF:07ID-ES1{DMR:I400-1}:IC4_MON", ## PK: Copied over ID from Beamstop_SAXS_int and just changed to "IC4", as the signal is coming from Channel 4.  Also confirmed the name on phoebus RSoXS archiver.
+    name="DM7 Photodiode", 
+    kind="normal" ## PK: following the other examples.  What does "normal" mean?
+)
 # DM7_Diode = EpicsSignalRO('XF:07ID-BI{DM7:I400-1}:IC4_MON',name = 'DM7 Photodiode', kind='normal')
 DM4_PD = EpicsSignalRO(
     "XF:07ID-BI{DM5:F4}Cur:I3-I", name="DM4 Photodiode", kind="normal"


### PR DESCRIPTION
I created a DM7_Photodiode_int signal in the signals.py file and added this signal to the list of signals/detectors in the energyscancore.py file.  

I mainly looked for places where Beamstop_WAXS_int was used, and added the DM7_Photodiode_int signal to the list.  I also saw  Beamstop_WAXS_int in fly_alignment.py (fly_find_fiducials function), alignment.py (spiral scans), and common_procedures.py (buildeputable), but I did not add the DM7_Photodiode_int signal to these files, as it did not seem relevant.  I also did not add the DM7_Photodiode_int signal into lines 626, 627, 636, and 637 of energyscancore.py for the same reason.  Let me know if I need to adjust anything.