### PR TITLE
Add tiff time stamp as read attr

### DIFF
--- a/rsoxs/devices/cameras.py
+++ b/rsoxs/devices/cameras.py
@@ -24,6 +24,7 @@ def StandardProsilicawstatsFactory(*args, camera_name="", date_template="%Y/%m/%
             md=bl.md,
             camera_name=camera_name,
             date_template=date_template,
+            read_attrs=["time_stamp"],
         )
         stats1 = Cpt(StatsWCentroid, "Stats1:", kind='hinted')
         stats2 = Cpt(StatsWCentroid, "Stats2:", read_attrs=["total"])

--- a/rsoxs/devices/detectors.py
+++ b/rsoxs/devices/detectors.py
@@ -98,7 +98,7 @@ class RSOXSGreatEyesDetector(SingleTriggerV33, GreatEyesDetector):
         md=bl.md,
         camera_name="waxs-1",
         date_template="%Y/%m/%d/",
-        read_attrs=[],
+        read_attrs=["time_stamp"],
         kind="hinted",
     )
 


### PR DESCRIPTION
Adds TIFF time stamps as a read attribute for the detectors that use this plugin.

Do not merge until the companion PR in sst_base is merged.